### PR TITLE
复用JsonSerializerOptions，优化性能

### DIFF
--- a/Blazor.ECharts/Options/EChartsOption.cs
+++ b/Blazor.ECharts/Options/EChartsOption.cs
@@ -3,8 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace Blazor.ECharts.Options
@@ -184,19 +182,10 @@ namespace Blazor.ECharts.Options
         /// </summary>
         public Brush Brush { set; get; }
         public BMap Bmap { get; set; }
+
         public override string ToString()
         {
-            JsonSerializerOptions jsonSerializerOptions = new()
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-                Converters =
-                {
-                    new JsonStringEnumConverter(JsonNamingPolicy.CamelCase),
-                    new JFuncConverter()
-                }
-            };
-            return JsonSerializer.Serialize(this, jsonSerializerOptions);
+            return EChartsOptionSerializer.Default.Serialize(this);
         }
     }
 }

--- a/Blazor.ECharts/Options/EChartsOptionSerializer.cs
+++ b/Blazor.ECharts/Options/EChartsOptionSerializer.cs
@@ -1,0 +1,31 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Blazor.ECharts.Options
+{
+    internal class EChartsOptionSerializer
+    {
+        public static readonly EChartsOptionSerializer Default = new();
+
+        private readonly JsonSerializerOptions _options;
+
+        private EChartsOptionSerializer()
+        {
+            _options = new()
+            {
+                PropertyNamingPolicy   = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                Converters =
+                {
+                    new JsonStringEnumConverter(JsonNamingPolicy.CamelCase),
+                    new JFuncConverter()
+                }
+            };
+        }
+
+        public string Serialize(object option)
+        {
+            return JsonSerializer.Serialize(option, _options);
+        }
+    }
+}


### PR DESCRIPTION
因为目前System.Text.Json把序列化信息保存在JsonSerializerOptions对象中，每次新建JsonSerializerOptions会造成较多的内存分配及反射，在界面上显示较多图表时会带来性能问题
详情可见：https://learn.microsoft.com/zh-cn/dotnet/standard/serialization/system-text-json-configure-options?pivots=dotnet-6-0#reuse-jsonserializeroptions-instances
